### PR TITLE
Definir la zone horaire pour la fonction strtotime()

### DIFF
--- a/lib/Cake/Cache/CacheEngine.php
+++ b/lib/Cake/Cache/CacheEngine.php
@@ -1,4 +1,5 @@
 <?php
+date_default_timezone_set('Europe/Paris');
 /**
  * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
  * Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)


### PR DESCRIPTION
Afin d’éviter d’obtenir l'avertissement :
Warning: strtotime(): It is not safe to rely on the system's timezone settings. You are *required* to use the date.timezone setting or the date_default_timezone_set() function. In case you used any of those methods and you are still getting this warning, you most likely misspelled the timezone identifier. We selected the timezone 'UTC' for now, but please set date.timezone to select your timezone. in C:\UwAmp\www\lib\Cake\Cache\CacheEngine.php on line 61
Il est nécessaire de définir la zone horaire  avec "date_default_timezone_set('Europe/Paris');" pour ne pas être sous l'heur utc par defaut mais bien à l'heur de paris (gtm+1) et ne pas avoir l'avertissement qui s'affiche.